### PR TITLE
V0.1.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ USER django
 
 EXPOSE 8000
 
-CMD gunicorn -b :8000 winearth.wsgi
+CMD gunicorn -b :8000 winearth.wsgi --log-level debug

--- a/winearth/settings.py
+++ b/winearth/settings.py
@@ -34,7 +34,7 @@ if "DEBUG" in os.environ:
 else:
     DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ["127.0.0.1", "winearth-api-server"]
 
 
 # Application definition


### PR DESCRIPTION
- [Set the gunicorn log-level to debug](https://github.com/windows-on-earth/winearth-api/commit/9c4e4c50198ceb5bc43379bf19c1f4594575c1ff)
- [Added 127.0.0.1 and winearth-api-server to ALLOWED_HOSTS](https://github.com/windows-on-earth/winearth-api/commit/367da70810fc60f20f93de8edeb5dc3b36303913)